### PR TITLE
잠금화면 개선 및 데스크톱 바로가기 정리

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -17,9 +17,9 @@
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>KimGyuWon's portfolio</title>
-    <script type="module" crossorigin src="/assets/index-Cx6TKWGi.js"></script>
+    <script type="module" crossorigin src="/assets/index-C2-ytuem.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-CWQXosb-.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-oO2rfpnz.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-D3moJ05h.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/FullscreenGate/FullscreenGate.tsx
+++ b/src/components/FullscreenGate/FullscreenGate.tsx
@@ -34,9 +34,18 @@ export default function FullscreenGate() {
   const markStarted = useStartStore((s) => s.markStarted);
 
   const [visible, setVisible] = useState(() => !started);
-  useEffect(() => setVisible(!started), [started]);
+  const [isEntering, setIsEntering] = useState(false);
+
+  useEffect(() => {
+    setVisible(!started);
+    if (!started) {
+      setIsEntering(false);
+    }
+  }, [started]);
 
   const enter = async () => {
+    if (isEntering) return;
+
     try {
       await request();
       await new Promise<void>((resolve) => {
@@ -58,13 +67,17 @@ export default function FullscreenGate() {
       });
     } catch {}
 
-    markStarted();
-    setVisible(false);
+    setIsEntering(true);
     playSystemSound('startup');
+
+    window.setTimeout(() => {
+      markStarted();
+      setVisible(false);
+    }, 220);
   };
 
   useEffect(() => {
-    if (!visible) return;
+    if (!visible || isEntering) return;
 
     const onKeyDown = () => {
       void enter();
@@ -72,43 +85,67 @@ export default function FullscreenGate() {
 
     window.addEventListener('keydown', onKeyDown, { once: true });
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [visible]);
+  }, [isEntering, visible]);
 
   if (!visible) return null;
 
   return (
     <button
       onClick={() => void enter()}
-      className='fixed inset-0 z-[10000] block select-none text-left text-white'
+      type='button'
+      aria-label='Enter portfolio'
+      className={[
+        'fixed inset-0 z-[10000] block select-none text-left text-white',
+        'transition-[opacity,transform] duration-300 ease-out',
+        isEntering ? 'pointer-events-none opacity-0 scale-[1.015]' : 'opacity-100',
+      ].join(' ')}
       style={getWallpaperStyle(wallpaperId)}
     >
       <div
-        className='absolute inset-0 bg-[linear-gradient(180deg,rgba(4,11,24,0.26)_0%,rgba(5,10,20,0.56)_100%)]'
+        className='absolute inset-0 bg-[radial-gradient(circle_at_28%_18%,rgba(255,255,255,0.12)_0%,transparent_20%),linear-gradient(180deg,rgba(4,11,24,0.16)_0%,rgba(5,10,20,0.36)_45%,rgba(5,10,20,0.68)_100%)]'
         aria-hidden
       />
 
       <div className='relative flex h-full flex-col justify-between px-6 py-8 md:px-10 md:py-10'>
         <div className='flex items-start justify-between'>
-          <div className='rounded-full border border-white/20 bg-black/20 px-4 py-2 text-xs font-medium tracking-[0.18em] text-white/80 backdrop-blur-xl'>
-            Click or press any key to unlock
+          <div className='rounded-full border border-white/16 bg-black/18 px-4 py-2 text-[11px] font-medium tracking-[0.16em] text-white/72 backdrop-blur-xl md:text-xs'>
+            Press any key or click anywhere
           </div>
           {visitorCount !== null ? (
-            <div className='rounded-full border border-white/20 bg-black/20 px-4 py-2 text-xs font-medium text-white/85 backdrop-blur-xl'>
+            <div className='rounded-full border border-white/16 bg-black/18 px-4 py-2 text-[11px] font-medium text-white/78 backdrop-blur-xl md:text-xs'>
               Visitors {visitorCount.toLocaleString()}
             </div>
           ) : null}
         </div>
 
-        <div className='max-w-[680px] pb-20'>
+        <div className='max-w-[680px] pb-10 md:pb-16'>
           <div className='text-[82px] font-semibold leading-none tracking-[-0.05em] md:text-[112px]'>
             {formatLockTime(now)}
           </div>
           <div className='mt-4 text-[22px] font-medium text-white/88 md:text-[28px]'>
             {formatLockDate(now)}
           </div>
-          <div className='mt-6 max-w-[520px] text-sm leading-7 text-white/76 md:text-[15px]'>
-            Windows-inspired shell for portfolio, projects, browser previews,
-            notes, and a curated code explorer.
+
+          <div className='mt-8 max-w-[620px]'>
+            <div className='text-[11px] font-medium uppercase tracking-[0.28em] text-white/62 md:text-xs'>
+              Frontend Developer
+            </div>
+            <div className='mt-3 text-[28px] font-semibold tracking-[-0.04em] text-white md:text-[40px]'>
+              김규원 Portfolio
+            </div>
+            <div className='mt-4 max-w-[560px] text-sm leading-7 text-white/74 md:text-[15px]'>
+              Projects, profile, notes, browser previews, and a live GitHub
+              workspace inside a Windows-inspired desktop shell.
+            </div>
+          </div>
+
+          <div className='mt-8 flex flex-wrap items-center gap-3 md:mt-10'>
+            <div className='inline-flex min-h-11 items-center rounded-full border border-white/22 bg-white/14 px-5 text-[13px] font-semibold tracking-[0.08em] text-white shadow-[0_12px_30px_rgba(7,12,24,0.18)] backdrop-blur-xl'>
+              Enter Portfolio
+            </div>
+            <div className='text-sm text-white/64'>
+              Click anywhere or press any key
+            </div>
           </div>
         </div>
       </div>

--- a/src/features/desktop/components/DesktopSurface.tsx
+++ b/src/features/desktop/components/DesktopSurface.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import { PAGE_TABS } from '@/features/pages-window/registry/page-registry';
 import { NOTE_COLORS, WALLPAPERS } from '@/features/desktop/config/shell';
-import { snapDesktopShortcutPosition } from '@/features/desktop/utils/shortcutGrid';
+import { resolveDesktopShortcutPosition } from '@/features/desktop/utils/shortcutGrid';
 import {
   useDesktopLayoutStore,
   useDesktopNotesStore,
@@ -81,6 +81,7 @@ function DesktopShortcutTile({
   onSelect,
   onOpen,
   onMove,
+  resolveDropPosition,
   onStartRename,
   onCommitRename,
   onContextMenu,
@@ -91,6 +92,7 @@ function DesktopShortcutTile({
   onSelect: () => void;
   onOpen: () => void;
   onMove: (position: DesktopPosition) => void;
+  resolveDropPosition: (position: DesktopPosition) => DesktopPosition;
   onStartRename: () => void;
   onCommitRename: (title: string) => void;
   onContextMenu: (event: MouseEvent) => void;
@@ -139,7 +141,7 @@ function DesktopShortcutTile({
       setDragging(true);
     }
 
-    setPreviewPosition(snapDesktopShortcutPosition(next));
+    setPreviewPosition(resolveDropPosition(next));
   };
 
   const onPointerUp = (event: PointerEvent<HTMLDivElement>) => {
@@ -397,6 +399,16 @@ export function DesktopSurface() {
     () => notes.filter((note) => note.surfaceVisible !== false),
     [notes]
   );
+  const resolveShortcutDropPosition = (
+    itemId: string,
+    position: DesktopPosition
+  ) =>
+    resolveDesktopShortcutPosition(
+      position,
+      items
+        .filter((item) => item.id !== itemId)
+        .map((item) => item.position)
+    );
 
   useEffect(() => {
     if (!contextMenu) return;
@@ -467,11 +479,7 @@ export function DesktopSurface() {
   const handleNewFolder = () => {
     const rect = surfaceRef.current?.getBoundingClientRect();
     if (!rect || !contextMenu) return;
-    const id = createFolder(
-      snapDesktopShortcutPosition(
-        toDesktopPosition(contextMenu.x, contextMenu.y, rect)
-      )
-    );
+    const id = createFolder(toDesktopPosition(contextMenu.x, contextMenu.y, rect));
     setSelectedId(id);
     setEditingFolderId(id);
     setContextMenu(null);
@@ -616,6 +624,9 @@ export function DesktopSurface() {
           }}
           onOpen={() => handleOpenItem(item)}
           onMove={(position) => moveItem(item.id, position)}
+          resolveDropPosition={(position) =>
+            resolveShortcutDropPosition(item.id, position)
+          }
           onStartRename={() => setEditingFolderId(item.id)}
           onCommitRename={(title) => {
             renameFolder(item.id, title);

--- a/src/features/desktop/utils/shortcutGrid.ts
+++ b/src/features/desktop/utils/shortcutGrid.ts
@@ -9,6 +9,16 @@ type Viewport = {
   height: number;
 };
 
+type GridBounds = {
+  maxColumn: number;
+  maxRow: number;
+};
+
+type GridCell = {
+  column: number;
+  row: number;
+};
+
 function getDefaultViewport(): Viewport {
   if (typeof window === 'undefined') {
     return { width: 1440, height: 900 };
@@ -24,36 +34,109 @@ function clampGridIndex(index: number, maxIndex: number) {
   return Math.max(0, Math.min(index, maxIndex));
 }
 
+function getGridBounds(viewport: Viewport): GridBounds {
+  return {
+    maxColumn: Math.max(
+      0,
+      Math.floor(
+        (viewport.width - DESKTOP_SHORTCUT_BOUNDS.x - DESKTOP_GRID_ORIGIN.x) /
+          DESKTOP_GRID_STEP.x
+      )
+    ),
+    maxRow: Math.max(
+      0,
+      Math.floor(
+        (viewport.height - DESKTOP_SHORTCUT_BOUNDS.y - DESKTOP_GRID_ORIGIN.y) /
+          DESKTOP_GRID_STEP.y
+      )
+    ),
+  };
+}
+
+function positionToGridCell(
+  position: DesktopPosition,
+  bounds: GridBounds
+): GridCell {
+  return {
+    column: clampGridIndex(
+      Math.round((position.x - DESKTOP_GRID_ORIGIN.x) / DESKTOP_GRID_STEP.x),
+      bounds.maxColumn
+    ),
+    row: clampGridIndex(
+      Math.round((position.y - DESKTOP_GRID_ORIGIN.y) / DESKTOP_GRID_STEP.y),
+      bounds.maxRow
+    ),
+  };
+}
+
+function gridCellToPosition(cell: GridCell): DesktopPosition {
+  return {
+    x: DESKTOP_GRID_ORIGIN.x + cell.column * DESKTOP_GRID_STEP.x,
+    y: DESKTOP_GRID_ORIGIN.y + cell.row * DESKTOP_GRID_STEP.y,
+  };
+}
+
+function getGridCellKey(cell: GridCell) {
+  return `${cell.column}:${cell.row}`;
+}
+
 export function snapDesktopShortcutPosition(
   position: DesktopPosition,
   viewport: Viewport = getDefaultViewport()
 ) {
-  const maxColumn = Math.max(
-    0,
-    Math.floor(
-      (viewport.width - DESKTOP_SHORTCUT_BOUNDS.x - DESKTOP_GRID_ORIGIN.x) /
-        DESKTOP_GRID_STEP.x
-    )
+  return gridCellToPosition(
+    positionToGridCell(position, getGridBounds(viewport))
   );
-  const maxRow = Math.max(
-    0,
-    Math.floor(
-      (viewport.height - DESKTOP_SHORTCUT_BOUNDS.y - DESKTOP_GRID_ORIGIN.y) /
-        DESKTOP_GRID_STEP.y
+}
+
+export function resolveDesktopShortcutPosition(
+  position: DesktopPosition,
+  occupiedPositions: DesktopPosition[],
+  viewport: Viewport = getDefaultViewport()
+) {
+  const bounds = getGridBounds(viewport);
+  const preferredCell = positionToGridCell(position, bounds);
+  const occupiedKeys = new Set(
+    occupiedPositions.map((entry) =>
+      getGridCellKey(positionToGridCell(entry, bounds))
     )
   );
 
-  const column = clampGridIndex(
-    Math.round((position.x - DESKTOP_GRID_ORIGIN.x) / DESKTOP_GRID_STEP.x),
-    maxColumn
-  );
-  const row = clampGridIndex(
-    Math.round((position.y - DESKTOP_GRID_ORIGIN.y) / DESKTOP_GRID_STEP.y),
-    maxRow
-  );
+  if (!occupiedKeys.has(getGridCellKey(preferredCell))) {
+    return gridCellToPosition(preferredCell);
+  }
 
-  return {
-    x: DESKTOP_GRID_ORIGIN.x + column * DESKTOP_GRID_STEP.x,
-    y: DESKTOP_GRID_ORIGIN.y + row * DESKTOP_GRID_STEP.y,
-  };
+  let bestCell: GridCell | null = null;
+  let bestManhattan = Number.POSITIVE_INFINITY;
+  let bestEuclidean = Number.POSITIVE_INFINITY;
+
+  for (let row = 0; row <= bounds.maxRow; row += 1) {
+    for (let column = 0; column <= bounds.maxColumn; column += 1) {
+      const candidate = { column, row };
+      if (occupiedKeys.has(getGridCellKey(candidate))) continue;
+
+      const dx = column - preferredCell.column;
+      const dy = row - preferredCell.row;
+      const manhattan = Math.abs(dx) + Math.abs(dy);
+      const euclidean = dx * dx + dy * dy;
+
+      if (
+        bestCell === null ||
+        manhattan < bestManhattan ||
+        (manhattan === bestManhattan && euclidean < bestEuclidean) ||
+        (manhattan === bestManhattan &&
+          euclidean === bestEuclidean &&
+          (row < bestCell.row ||
+            (row === bestCell.row && column < bestCell.column)))
+      ) {
+        bestCell = candidate;
+        bestManhattan = manhattan;
+        bestEuclidean = euclidean;
+      }
+    }
+  }
+
+  return bestCell
+    ? gridCellToPosition(bestCell)
+    : gridCellToPosition(preferredCell);
 }

--- a/src/stores/useDesktopLayoutStore.ts
+++ b/src/stores/useDesktopLayoutStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { DEFAULT_DESKTOP_ITEMS } from '@/features/desktop/config/shell';
-import { snapDesktopShortcutPosition } from '@/features/desktop/utils/shortcutGrid';
+import { resolveDesktopShortcutPosition } from '@/features/desktop/utils/shortcutGrid';
 import type {
   DesktopPosition,
   DesktopShortcutItem,
@@ -24,22 +24,32 @@ function normalizeLayoutItems(
 ): DesktopShortcutItem[] {
   const storedItems = items ?? [];
   const defaultIds = new Set(DEFAULT_DESKTOP_ITEMS.map((item) => item.id));
+  const occupiedPositions: DesktopPosition[] = [];
+
+  const reservePosition = (position: DesktopPosition) => {
+    const resolved = resolveDesktopShortcutPosition(position, occupiedPositions);
+    occupiedPositions.push(resolved);
+    return resolved;
+  };
 
   const systemItems = DEFAULT_DESKTOP_ITEMS.map((defaultItem) => {
     const storedItem = storedItems.find((item) => item.id === defaultItem.id);
     return storedItem
       ? {
           ...defaultItem,
-          position: snapDesktopShortcutPosition(storedItem.position),
+          position: reservePosition(storedItem.position),
         }
-      : defaultItem;
+      : {
+          ...defaultItem,
+          position: reservePosition(defaultItem.position),
+        };
   });
 
   const customItems = storedItems
     .filter((item) => !defaultIds.has(item.id))
     .map((item) => ({
       ...item,
-      position: snapDesktopShortcutPosition(item.position),
+      position: reservePosition(item.position),
     }));
   return [...systemItems, ...customItems];
 }
@@ -54,7 +64,12 @@ export const useDesktopLayoutStore = create<LayoutState>()(
             item.id === id
               ? {
                   ...item,
-                  position: snapDesktopShortcutPosition(position),
+                  position: resolveDesktopShortcutPosition(
+                    position,
+                    s.items
+                      .filter((entry) => entry.id !== id)
+                      .map((entry) => entry.position)
+                  ),
                 }
               : item
           ),
@@ -71,7 +86,10 @@ export const useDesktopLayoutStore = create<LayoutState>()(
               contentType: 'user-folder',
               title: 'New Folder',
               icon: '/assets/common/desktop/folder-shortcut.webp',
-              position: snapDesktopShortcutPosition(position),
+              position: resolveDesktopShortcutPosition(
+                position,
+                s.items.map((item) => item.position)
+              ),
               mutable: true,
             },
           ],


### PR DESCRIPTION
## 관련 이슈
- #71

## 변경 사항
- 잠금화면 카피 및 진입 전환 정리
- 데스크톱 바로가기 빈 슬롯 우선 배치 적용
- 드래그 미리보기 단계 충돌 방지 반영
- 빌드 산출물 갱신

## 검증
- npm run build
- npm run lint 실행 실패: eslint 실행 파일 누락