### PR TITLE
feat: add galaxy-style mobile shell

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -9,6 +9,7 @@
       as="image"
       href="/assets/common/desktop/windows-cloud-wallpaper.webp"
       fetchpriority="high"
+      media="(min-width: 768px)"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
@@ -96,9 +97,9 @@
       }
     </script>
     <title>김규원 | Frontend Developer Portfolio</title>
-    <script type="module" crossorigin src="/assets/index-17MNJAix.js"></script>
-    <link rel="modulepreload" crossorigin href="/assets/vendor-CWQXosb-.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-COwGbl8O.css">
+    <script type="module" crossorigin src="/assets/index-Df106DMn.js"></script>
+    <link rel="modulepreload" crossorigin href="/assets/vendor-eEVuUEdO.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-PsWCexk1.css">
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
       as="image"
       href="/assets/common/desktop/windows-cloud-wallpaper.webp"
       fetchpriority="high"
+      media="(min-width: 768px)"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta

--- a/src/components/FullscreenGate/FullscreenGate.tsx
+++ b/src/components/FullscreenGate/FullscreenGate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { getWallpaperStyle } from '@/features/desktop/config/shell';
 import { useClock } from '@/hooks/useClock';
 import { useFullscreen } from '@/hooks/useFullscreen';
@@ -22,6 +22,13 @@ function formatLockDate(now: Date) {
     day: 'numeric',
   }).format(now);
 }
+
+const PHONE_LOCK_STYLE: CSSProperties = {
+  backgroundImage:
+    'linear-gradient(145deg, rgba(9,20,44,0.9) 0%, rgba(39,44,91,0.64) 34%, rgba(165,68,128,0.5) 62%, rgba(32,146,156,0.66) 100%), linear-gradient(28deg, #07111f 0%, #172554 32%, #5b2f87 58%, #0f766e 100%)',
+  backgroundSize: 'cover',
+  backgroundPosition: 'center',
+};
 
 export default function FullscreenGate() {
   const { request } = useFullscreen();
@@ -87,61 +94,106 @@ export default function FullscreenGate() {
 
   if (!visible) return null;
 
+  const gateClassName = [
+    'fixed inset-0 z-[10000] select-none text-left text-white',
+    'transition-[opacity,transform] duration-300 ease-out',
+    isEntering ? 'pointer-events-none opacity-0 scale-[1.015]' : 'opacity-100',
+  ].join(' ');
+
   return (
-    <button
-      onClick={() => void enter()}
-      type='button'
-      aria-label='Enter portfolio'
-      className={[
-        'fixed inset-0 z-[10000] block select-none text-left text-white',
-        'transition-[opacity,transform] duration-300 ease-out',
-        isEntering ? 'pointer-events-none opacity-0 scale-[1.015]' : 'opacity-100',
-      ].join(' ')}
-      style={getWallpaperStyle(wallpaperId)}
-    >
-      <div
-        className='absolute inset-0 bg-[radial-gradient(circle_at_28%_18%,rgba(255,255,255,0.12)_0%,transparent_20%),linear-gradient(180deg,rgba(4,11,24,0.16)_0%,rgba(5,10,20,0.36)_45%,rgba(5,10,20,0.68)_100%)]'
-        aria-hidden
-      />
+    <>
+      <button
+        onClick={() => void enter()}
+        type='button'
+        aria-label='Enter portfolio'
+        className={`${gateClassName} block md:hidden`}
+        style={PHONE_LOCK_STYLE}
+      >
+        <div
+          className='absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.08)_0%,rgba(255,255,255,0)_26%,rgba(0,0,0,0.28)_100%)]'
+          aria-hidden
+        />
 
-      <div className='relative flex h-full flex-col justify-between px-6 py-8 md:px-10 md:py-10'>
-        <div className='flex items-start justify-between'>
-          <div className='rounded-full border border-white/16 bg-black/18 px-4 py-2 text-[11px] font-medium tracking-[0.16em] text-white/72 backdrop-blur-xl md:text-xs'>
-            Press any key or click anywhere
-          </div>
-        </div>
-
-        <div className='max-w-[680px] pb-10 md:pb-16'>
-          <div className='text-[82px] font-semibold leading-none tracking-[-0.05em] md:text-[112px]'>
-            {formatLockTime(now)}
-          </div>
-          <div className='mt-4 text-[22px] font-medium text-white/88 md:text-[28px]'>
-            {formatLockDate(now)}
+        <div className='relative flex h-full flex-col px-6 pb-9 pt-5'>
+          <div className='flex h-7 items-center justify-between text-[12px] font-semibold'>
+            <span>{formatLockTime(now)}</span>
+            <span>5G  86%</span>
           </div>
 
-          <div className='mt-8 max-w-[620px]'>
-            <div className='text-[11px] font-medium uppercase tracking-[0.28em] text-white/62 md:text-xs'>
-              Frontend Developer
+          <div className='mt-16 text-center'>
+            <div className='text-[74px] font-light leading-none'>
+              {formatLockTime(now)}
             </div>
-            <div className='mt-3 text-[28px] font-semibold tracking-[-0.04em] text-white md:text-[40px]'>
-              김규원 Portfolio
-            </div>
-            <div className='mt-4 max-w-[560px] text-sm leading-7 text-white/74 md:text-[15px]'>
-              Projects, profile, notes, browser previews, and a live GitHub
-              workspace inside a Windows-inspired desktop shell.
+            <div className='mt-4 text-[17px] font-medium text-white/86'>
+              {formatLockDate(now)}
             </div>
           </div>
 
-          <div className='mt-8 flex flex-wrap items-center gap-3 md:mt-10'>
-            <div className='inline-flex min-h-11 items-center rounded-full border border-white/22 bg-white/14 px-5 text-[13px] font-semibold tracking-[0.08em] text-white shadow-[0_12px_30px_rgba(7,12,24,0.18)] backdrop-blur-xl'>
-              Enter Portfolio
+          <div className='mt-auto space-y-3'>
+            <div className='rounded-[26px] bg-white/18 px-5 py-4 shadow-[0_18px_40px_rgba(0,0,0,0.2)] ring-1 ring-white/18 backdrop-blur-2xl'>
+              <div className='text-[13px] font-semibold'>One UI Portfolio</div>
+              <div className='mt-1 text-[12px] leading-5 text-white/72'>
+                Your portfolio workspace is ready.
+              </div>
             </div>
-            <div className='text-sm text-white/64'>
-              Click anywhere or press any key
+            <div className='mx-auto flex h-11 w-[176px] items-center justify-center rounded-full bg-white/16 text-[13px] font-semibold ring-1 ring-white/18 backdrop-blur-xl'>
+              Tap to unlock
             </div>
           </div>
         </div>
-      </div>
-    </button>
+      </button>
+
+      <button
+        onClick={() => void enter()}
+        type='button'
+        aria-label='Enter portfolio'
+        className={`${gateClassName} hidden md:block`}
+        style={getWallpaperStyle(wallpaperId)}
+      >
+        <div
+          className='absolute inset-0 bg-[radial-gradient(circle_at_28%_18%,rgba(255,255,255,0.12)_0%,transparent_20%),linear-gradient(180deg,rgba(4,11,24,0.16)_0%,rgba(5,10,20,0.36)_45%,rgba(5,10,20,0.68)_100%)]'
+          aria-hidden
+        />
+
+        <div className='relative flex h-full flex-col justify-between px-6 py-8 md:px-10 md:py-10'>
+          <div className='flex items-start justify-between'>
+            <div className='rounded-full border border-white/16 bg-black/18 px-4 py-2 text-[11px] font-medium tracking-[0.16em] text-white/72 backdrop-blur-xl md:text-xs'>
+              Press any key or click anywhere
+            </div>
+          </div>
+
+          <div className='max-w-[680px] pb-10 md:pb-16'>
+            <div className='text-[82px] font-semibold leading-none tracking-[-0.05em] md:text-[112px]'>
+              {formatLockTime(now)}
+            </div>
+            <div className='mt-4 text-[22px] font-medium text-white/88 md:text-[28px]'>
+              {formatLockDate(now)}
+            </div>
+
+            <div className='mt-8 max-w-[620px]'>
+              <div className='text-[11px] font-medium uppercase tracking-[0.28em] text-white/62 md:text-xs'>
+                Frontend Developer
+              </div>
+              <div className='mt-3 text-[28px] font-semibold tracking-[-0.04em] text-white md:text-[40px]'>
+                Kim GyuWon Portfolio
+              </div>
+              <div className='mt-4 max-w-[560px] text-sm leading-7 text-white/74 md:text-[15px]'>
+                Projects, profile, notes, browser previews, and a live GitHub
+                workspace inside a Windows-inspired desktop shell.
+              </div>
+            </div>
+
+            <div className='mt-8 flex flex-wrap items-center gap-3 md:mt-10'>
+              <div className='inline-flex min-h-11 items-center rounded-full border border-white/22 bg-white/14 px-5 text-[13px] font-semibold tracking-[0.08em] text-white shadow-[0_12px_30px_rgba(7,12,24,0.18)] backdrop-blur-xl'>
+                Enter Portfolio
+              </div>
+              <div className='text-sm text-white/64'>
+                Click anywhere or press any key
+              </div>
+            </div>
+          </div>
+        </div>
+      </button>
+    </>
   );
 }

--- a/src/features/mobile/components/GalaxyPhoneShell.tsx
+++ b/src/features/mobile/components/GalaxyPhoneShell.tsx
@@ -1,0 +1,1010 @@
+import {
+  lazy,
+  Suspense,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent,
+  type ReactNode,
+} from 'react';
+import { CODE_WORKSPACES } from '@/features/desktop/config/shell';
+import {
+  PageScrollContainerProvider,
+  PAGES_SCROLL_CONTAINER_ID,
+} from '@/features/pages-window/context/PageScrollContext';
+import { PageContent } from '@/features/pages-window/registry/PageContent';
+import { PAGE_TABS } from '@/features/pages-window/registry/page-registry';
+import { useClock } from '@/hooks/useClock';
+import { useDesktopPreferencesStore } from '@/stores';
+import type { TextFileId } from '@/stores';
+import { useImagePreload } from '@/utils/preloadAssets';
+import {
+  PHONE_APP_BY_ID,
+  PHONE_APPS,
+  PHONE_DOCK_APP_IDS,
+  PHONE_FOLDER_APP_IDS,
+  PHONE_FOLDER_TITLES,
+  PHONE_HOME_APP_IDS,
+  PHONE_SYSTEM_ICONS,
+  type PhoneApp,
+  type PhoneFolderId,
+  type PhoneLaunch,
+} from '../config/galaxyShell';
+
+const NotepadWindowBody = lazy(async () => {
+  const module = await import(
+    '@/features/notepad-window/components/NotepadWindowBody'
+  );
+  return { default: module.NotepadWindowBody };
+});
+
+const TerminalWindowBody = lazy(async () => {
+  const module = await import(
+    '@/features/terminal-window/components/TerminalWindowBody'
+  );
+  return { default: module.TerminalWindowBody };
+});
+
+const Github1sCodeWindow = lazy(async () => {
+  const module = await import(
+    '@/features/code-window/components/Github1sCodeWindow'
+  );
+  return { default: module.Github1sCodeWindow };
+});
+
+type RunnablePhoneLaunch = Exclude<PhoneLaunch, { kind: 'folder' }>;
+
+export type PhoneInitialApp = RunnablePhoneLaunch;
+
+type PhoneActiveApp = {
+  key: string;
+  title: string;
+  icon: string;
+  launch: RunnablePhoneLaunch;
+};
+
+const PHONE_IMAGE_ASSETS = PHONE_APPS.map((app) => app.icon).filter((src) =>
+  src.startsWith('/')
+);
+
+const TEXT_FILE_TITLES: Record<TextFileId, string> = {
+  readme: 'Notes',
+  'about-file': 'About',
+  contact: 'Phone',
+  now: 'Messages',
+  resume: 'Resume',
+};
+
+function isRunnableLaunch(launch: PhoneLaunch): launch is RunnablePhoneLaunch {
+  return launch.kind !== 'folder';
+}
+
+function getLaunchKey(launch: RunnablePhoneLaunch) {
+  switch (launch.kind) {
+    case 'page':
+      return `page:${launch.pageId}`;
+    case 'text-file':
+      return `text-file:${launch.fileId}`;
+    case 'code':
+      return `code:${launch.workspaceId}`;
+    case 'terminal':
+      return 'terminal:main';
+  }
+}
+
+function getFallbackTitle(launch: RunnablePhoneLaunch) {
+  switch (launch.kind) {
+    case 'page':
+      return PAGE_TABS[launch.pageId].title;
+    case 'text-file':
+      return TEXT_FILE_TITLES[launch.fileId];
+    case 'code':
+      return CODE_WORKSPACES[launch.workspaceId].title;
+    case 'terminal':
+      return 'Terminal';
+  }
+}
+
+function getFallbackIcon(launch: RunnablePhoneLaunch) {
+  switch (launch.kind) {
+    case 'page':
+      return PAGE_TABS[launch.pageId].icon;
+    case 'text-file':
+      return PHONE_SYSTEM_ICONS.notes;
+    case 'code':
+      return PHONE_SYSTEM_ICONS.code;
+    case 'terminal':
+      return PHONE_SYSTEM_ICONS.terminal;
+  }
+}
+
+function getActiveAppFromLaunch(launch: RunnablePhoneLaunch): PhoneActiveApp {
+  const key = getLaunchKey(launch);
+  const matchedApp = PHONE_APPS.find(
+    (app) => isRunnableLaunch(app.launch) && getLaunchKey(app.launch) === key
+  );
+
+  return {
+    key,
+    title: matchedApp?.label ?? getFallbackTitle(launch),
+    icon: matchedApp?.icon ?? getFallbackIcon(launch),
+    launch,
+  };
+}
+
+function formatTime(now: Date) {
+  return new Intl.DateTimeFormat('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(now);
+}
+
+function formatHomeDate(now: Date) {
+  return new Intl.DateTimeFormat('ko-KR', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  }).format(now);
+}
+
+function SignalIcon({ className = 'h-4 w-4' }: { className?: string }) {
+  return (
+    <svg viewBox='0 0 18 18' className={className} aria-hidden='true'>
+      <path
+        d='M2 14.5h2.2V9.8H2zm4 0h2.2V7.3H6zm4 0h2.2V4.6H10zm4 0h2.2V2H14z'
+        fill='currentColor'
+      />
+    </svg>
+  );
+}
+
+function WifiIcon({ className = 'h-4 w-4' }: { className?: string }) {
+  return (
+    <svg viewBox='0 0 18 18' className={className} aria-hidden='true'>
+      <path
+        d='M9 14.6 6.8 12.4a3.1 3.1 0 0 1 4.4 0zm0-4.2L4.8 6.7a6.6 6.6 0 0 1 8.4 0zm0-4.1L2 3.8a10.8 10.8 0 0 1 14 0z'
+        fill='currentColor'
+      />
+    </svg>
+  );
+}
+
+function BatteryIcon({ className = 'h-4 w-5' }: { className?: string }) {
+  return (
+    <svg viewBox='0 0 24 18' className={className} aria-hidden='true'>
+      <rect
+        x='1.5'
+        y='4.2'
+        width='18'
+        height='9.6'
+        rx='3'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='1.8'
+      />
+      <rect x='4.1' y='6.8' width='11.4' height='4.4' rx='1.4' fill='currentColor' />
+      <rect x='20.5' y='7' width='2' height='4' rx='1' fill='currentColor' />
+    </svg>
+  );
+}
+
+function BackIcon() {
+  return (
+    <svg viewBox='0 0 24 24' className='h-6 w-6' aria-hidden='true'>
+      <path
+        d='M15 5 8 12l7 7'
+        fill='none'
+        stroke='currentColor'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        strokeWidth='2.4'
+      />
+    </svg>
+  );
+}
+
+function SearchIcon() {
+  return (
+    <svg viewBox='0 0 24 24' className='h-5 w-5' aria-hidden='true'>
+      <path
+        d='m20 20-4.5-4.5M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z'
+        fill='none'
+        stroke='currentColor'
+        strokeLinecap='round'
+        strokeWidth='2'
+      />
+    </svg>
+  );
+}
+
+function RecentIcon() {
+  return (
+    <svg viewBox='0 0 24 24' className='h-6 w-6' aria-hidden='true'>
+      <rect
+        x='5'
+        y='5'
+        width='14'
+        height='14'
+        rx='3.5'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='2'
+      />
+    </svg>
+  );
+}
+
+function HomeIcon() {
+  return (
+    <svg viewBox='0 0 24 24' className='h-6 w-6' aria-hidden='true'>
+      <circle cx='12' cy='12' r='5.2' fill='none' stroke='currentColor' strokeWidth='2' />
+    </svg>
+  );
+}
+
+function DrawerIcon() {
+  return (
+    <svg viewBox='0 0 24 24' className='h-5 w-5' aria-hidden='true'>
+      <path
+        d='m7 14 5-5 5 5'
+        fill='none'
+        stroke='currentColor'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        strokeWidth='2.2'
+      />
+    </svg>
+  );
+}
+
+function PhoneStatusBar({
+  now,
+  dark,
+  onOpenQuickPanel,
+}: {
+  now: Date;
+  dark: boolean;
+  onOpenQuickPanel: () => void;
+}) {
+  return (
+    <button
+      type='button'
+      aria-label='Open quick settings'
+      onClick={onOpenQuickPanel}
+      className={[
+        'flex h-8 w-full shrink-0 items-center justify-between px-5 pt-1 text-[12px] font-semibold',
+        dark ? 'text-[#111827]' : 'text-white drop-shadow',
+      ].join(' ')}
+    >
+      <span>{formatTime(now)}</span>
+      <span className='flex items-center gap-1.5'>
+        <SignalIcon />
+        <WifiIcon />
+        <span className='text-[11px]'>86%</span>
+        <BatteryIcon />
+      </span>
+    </button>
+  );
+}
+
+function FolderIconPreview({ folderId }: { folderId: PhoneFolderId }) {
+  const previewApps = PHONE_FOLDER_APP_IDS[folderId]
+    .slice(0, 4)
+    .map((id) => PHONE_APP_BY_ID.get(id))
+    .filter((app): app is PhoneApp => Boolean(app));
+
+  return (
+    <div className='grid h-full w-full grid-cols-2 gap-1.5 rounded-[20px] bg-white/92 p-2 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.4)]'>
+      {previewApps.map((app) => (
+        <img
+          key={app.id}
+          src={app.icon}
+          alt=''
+          className='h-full w-full rounded-[9px] object-cover'
+          draggable={false}
+        />
+      ))}
+    </div>
+  );
+}
+
+function PhoneAppIcon({
+  app,
+  onLaunch,
+  dense = false,
+}: {
+  app: PhoneApp;
+  onLaunch: (app: PhoneApp) => void;
+  dense?: boolean;
+}) {
+  const isFolder = app.launch.kind === 'folder';
+
+  return (
+    <button
+      type='button'
+      onClick={() => onLaunch(app)}
+      className='group flex min-w-0 flex-col items-center gap-1.5 text-white outline-none'
+      aria-label={app.label}
+    >
+      <span
+        className={[
+          'grid shrink-0 place-items-center overflow-hidden rounded-[21px] shadow-[0_10px_22px_rgba(0,0,0,0.2)] ring-1 ring-white/16 transition-transform group-active:scale-95',
+          dense ? 'h-[50px] w-[50px]' : 'h-[56px] w-[56px]',
+          isFolder ? 'bg-white/16 p-0' : 'bg-white/10',
+        ].join(' ')}
+      >
+        {isFolder ? (
+          <FolderIconPreview folderId={app.launch.folderId} />
+        ) : (
+          <img
+            src={app.icon}
+            alt=''
+            className='h-full w-full object-cover'
+            draggable={false}
+          />
+        )}
+      </span>
+      <span
+        className={[
+          'max-w-[76px] text-center font-medium leading-tight drop-shadow',
+          dense ? 'text-[10px]' : 'text-[11px]',
+        ].join(' ')}
+      >
+        {app.label}
+      </span>
+    </button>
+  );
+}
+
+function HomeScreen({
+  now,
+  onLaunch,
+  onOpenDrawer,
+  onPointerDown,
+  onPointerUp,
+}: {
+  now: Date;
+  onLaunch: (app: PhoneApp) => void;
+  onOpenDrawer: () => void;
+  onPointerDown: (event: PointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: PointerEvent<HTMLDivElement>) => void;
+}) {
+  const homeApps = PHONE_HOME_APP_IDS.map((id) => PHONE_APP_BY_ID.get(id)).filter(
+    (app): app is PhoneApp => Boolean(app)
+  );
+  const dockApps = PHONE_DOCK_APP_IDS.map((id) => PHONE_APP_BY_ID.get(id)).filter(
+    (app): app is PhoneApp => Boolean(app)
+  );
+
+  return (
+    <div
+      className='flex h-full min-h-0 flex-col px-5 pb-3 pt-3'
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+    >
+      <section className='mb-5 mt-1 rounded-[32px] bg-black/16 px-5 py-4 text-white shadow-[0_18px_44px_rgba(0,0,0,0.18)] ring-1 ring-white/14 backdrop-blur-2xl'>
+        <div className='text-[42px] font-light leading-none'>{formatTime(now)}</div>
+        <div className='mt-2 text-[13px] font-medium text-white/82'>
+          {formatHomeDate(now)}
+        </div>
+        <div className='mt-4 flex items-center justify-between gap-3 text-[12px] text-white/80'>
+          <span>Seoul</span>
+          <span className='rounded-full bg-white/16 px-3 py-1'>One UI Portfolio</span>
+        </div>
+      </section>
+
+      <div className='grid grid-cols-4 gap-x-3 gap-y-5'>
+        {homeApps.map((app) => (
+          <PhoneAppIcon key={app.id} app={app} onLaunch={onLaunch} />
+        ))}
+      </div>
+
+      <button
+        type='button'
+        onClick={onOpenDrawer}
+        className='mx-auto mt-auto grid h-9 w-24 place-items-center rounded-full bg-black/14 text-white ring-1 ring-white/12 backdrop-blur-xl'
+        aria-label='Open apps'
+      >
+        <DrawerIcon />
+      </button>
+
+      <div className='mt-3 grid grid-cols-4 gap-3 rounded-[30px] bg-black/22 px-4 py-3 shadow-[0_18px_42px_rgba(0,0,0,0.22)] ring-1 ring-white/12 backdrop-blur-2xl'>
+        {dockApps.map((app) => (
+          <PhoneAppIcon key={app.id} app={app} onLaunch={onLaunch} dense />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function QuickTile({
+  label,
+  active,
+  onClick,
+  children,
+}: {
+  label: string;
+  active?: boolean;
+  onClick?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className={[
+        'flex h-[82px] flex-col justify-between rounded-[24px] px-4 py-3 text-left transition-colors',
+        active
+          ? 'bg-[#2f6cff] text-white shadow-[0_12px_28px_rgba(47,108,255,0.28)]'
+          : 'bg-white/72 text-[#111827] ring-1 ring-black/5',
+      ].join(' ')}
+    >
+      <span className='text-[22px]'>{children}</span>
+      <span className='text-[12px] font-semibold'>{label}</span>
+    </button>
+  );
+}
+
+function QuickSettingsPanel({
+  open,
+  now,
+  soundEnabled,
+  onClose,
+  onToggleSound,
+  onOpenSettings,
+}: {
+  open: boolean;
+  now: Date;
+  soundEnabled: boolean;
+  onClose: () => void;
+  onToggleSound: () => void;
+  onOpenSettings: () => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div className='absolute inset-0 z-[80] bg-black/32 px-3 pt-2 text-[#111827] backdrop-blur-md'>
+      <button
+        type='button'
+        aria-label='Close quick settings'
+        className='absolute inset-0 h-full w-full cursor-default'
+        onClick={onClose}
+      />
+      <div
+        className='relative rounded-[34px] bg-[#eef2f8]/96 p-4 shadow-[0_24px_72px_rgba(0,0,0,0.34)] ring-1 ring-white/70 backdrop-blur-3xl'
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className='flex items-start justify-between gap-4 px-1'>
+          <div>
+            <div className='text-[28px] font-semibold leading-none'>{formatTime(now)}</div>
+            <div className='mt-2 text-[13px] text-[#475467]'>{formatHomeDate(now)}</div>
+          </div>
+          <button
+            type='button'
+            onClick={onOpenSettings}
+            className='rounded-full bg-white/80 px-4 py-2 text-[12px] font-semibold text-[#111827] shadow-sm ring-1 ring-black/5'
+          >
+            Settings
+          </button>
+        </div>
+
+        <div className='mt-5 grid grid-cols-2 gap-3'>
+          <QuickTile label='Wi-Fi' active>
+            <WifiIcon className='h-6 w-6' />
+          </QuickTile>
+          <QuickTile label='Sound' active={soundEnabled} onClick={onToggleSound}>
+            {soundEnabled ? '♪' : '×'}
+          </QuickTile>
+          <QuickTile label='Bluetooth'>B</QuickTile>
+          <QuickTile label='Location' active>
+            ◇
+          </QuickTile>
+        </div>
+
+        <div className='mt-4 rounded-[24px] bg-white/72 px-4 py-3 ring-1 ring-black/5'>
+          <div className='mb-3 flex items-center justify-between text-[12px] font-semibold text-[#475467]'>
+            <span>Brightness</span>
+            <span>72%</span>
+          </div>
+          <div className='h-3 rounded-full bg-[#d0d5dd]'>
+            <div className='h-full w-[72%] rounded-full bg-[#2f6cff]' />
+          </div>
+        </div>
+
+        <div className='mt-4 rounded-[24px] bg-white/72 px-4 py-3 ring-1 ring-black/5'>
+          <div className='text-[12px] font-semibold text-[#475467]'>Notifications</div>
+          <div className='mt-2 text-[14px] font-semibold'>Portfolio is ready</div>
+          <div className='mt-1 text-[12px] leading-5 text-[#667085]'>
+            Kim GyuWon portfolio is up to date.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FolderOverlay({
+  folderId,
+  onClose,
+  onLaunch,
+}: {
+  folderId: PhoneFolderId | null;
+  onClose: () => void;
+  onLaunch: (app: PhoneApp) => void;
+}) {
+  if (!folderId) return null;
+
+  const apps = PHONE_FOLDER_APP_IDS[folderId]
+    .map((id) => PHONE_APP_BY_ID.get(id))
+    .filter((app): app is PhoneApp => Boolean(app));
+
+  return (
+    <div className='absolute inset-0 z-[60] px-4 pt-[78px] text-white'>
+      <button
+        type='button'
+        aria-label='Close folder'
+        className='absolute inset-0 h-full w-full bg-black/24 backdrop-blur-sm'
+        onClick={onClose}
+      />
+      <div className='relative rounded-[34px] bg-white/18 p-5 shadow-[0_24px_72px_rgba(0,0,0,0.34)] ring-1 ring-white/28 backdrop-blur-3xl'>
+        <div className='mb-5 flex items-center justify-between gap-3'>
+          <div className='text-[22px] font-semibold'>{PHONE_FOLDER_TITLES[folderId]}</div>
+          <button
+            type='button'
+            onClick={onClose}
+            className='grid h-9 w-9 place-items-center rounded-full bg-white/16 text-[20px]'
+            aria-label='Close'
+          >
+            ×
+          </button>
+        </div>
+        <div className='grid grid-cols-3 gap-x-5 gap-y-6'>
+          {apps.map((app) => (
+            <PhoneAppIcon key={app.id} app={app} onLaunch={onLaunch} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AppDrawer({
+  open,
+  query,
+  onQueryChange,
+  onClose,
+  onLaunch,
+}: {
+  open: boolean;
+  query: string;
+  onQueryChange: (value: string) => void;
+  onClose: () => void;
+  onLaunch: (app: PhoneApp) => void;
+}) {
+  const filteredApps = PHONE_APPS.filter((app) =>
+    app.label.toLowerCase().includes(query.trim().toLowerCase())
+  );
+
+  if (!open) return null;
+
+  return (
+    <div className='absolute inset-0 z-[55] flex flex-col bg-black/34 px-5 pb-5 pt-12 text-white backdrop-blur-2xl'>
+      <div className='flex items-center justify-between'>
+        <div className='text-[24px] font-semibold'>Apps</div>
+        <button
+          type='button'
+          onClick={onClose}
+          className='grid h-10 w-10 place-items-center rounded-full bg-white/14 text-[22px]'
+          aria-label='Close apps'
+        >
+          ×
+        </button>
+      </div>
+      <label className='mt-5 flex h-12 items-center gap-3 rounded-full bg-white/18 px-4 text-white ring-1 ring-white/16'>
+        <SearchIcon />
+        <input
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+          placeholder='Finder search'
+          className='min-w-0 flex-1 bg-transparent text-[14px] font-medium outline-none placeholder:text-white/58'
+        />
+      </label>
+
+      <div className='app-scroll mt-6 min-h-0 flex-1 overflow-y-auto pb-3'>
+        {filteredApps.length > 0 ? (
+          <div className='grid grid-cols-4 gap-x-3 gap-y-6'>
+            {filteredApps.map((app) => (
+              <PhoneAppIcon key={app.id} app={app} onLaunch={onLaunch} />
+            ))}
+          </div>
+        ) : (
+          <div className='rounded-[28px] bg-white/14 p-5 text-center text-sm text-white/78'>
+            No results
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RecentsOverlay({
+  open,
+  recentApps,
+  onClose,
+  onResume,
+}: {
+  open: boolean;
+  recentApps: PhoneActiveApp[];
+  onClose: () => void;
+  onResume: (app: PhoneActiveApp) => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div className='absolute inset-0 z-[70] bg-black/42 px-5 pb-20 pt-14 text-white backdrop-blur-xl'>
+      <div className='mb-5 flex items-center justify-between'>
+        <div className='text-[22px] font-semibold'>Recent apps</div>
+        <button
+          type='button'
+          onClick={onClose}
+          className='rounded-full bg-white/14 px-4 py-2 text-[12px] font-semibold'
+        >
+          Close
+        </button>
+      </div>
+      {recentApps.length > 0 ? (
+        <div className='grid grid-cols-2 gap-4'>
+          {recentApps.map((app) => (
+            <button
+              type='button'
+              key={app.key}
+              onClick={() => onResume(app)}
+              className='min-h-[188px] rounded-[28px] bg-white/16 p-4 text-left shadow-[0_20px_52px_rgba(0,0,0,0.24)] ring-1 ring-white/18 backdrop-blur-2xl'
+            >
+              <div className='flex items-center gap-3'>
+                <img
+                  src={app.icon}
+                  alt=''
+                  className='h-10 w-10 rounded-[15px] object-cover'
+                />
+                <span className='text-sm font-semibold'>{app.title}</span>
+              </div>
+              <div className='mt-5 h-24 rounded-[22px] bg-white/78 p-4 text-[#111827]'>
+                <div className='text-[12px] font-semibold text-[#667085]'>Preview</div>
+                <div className='mt-2 text-[20px] font-semibold'>{app.title}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className='grid h-full place-items-center text-sm text-white/74'>
+          No recent apps
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PhoneAppContent({ app }: { app: PhoneActiveApp }) {
+  switch (app.launch.kind) {
+    case 'page':
+      return (
+        <div
+          id={PAGES_SCROLL_CONTAINER_ID}
+          className='app-scroll h-full min-h-0 overflow-y-auto overscroll-y-contain bg-[#f8fafc] [&_iframe]:h-full [&_iframe]:w-full [&_img]:h-auto [&_img]:max-w-full'
+        >
+          <PageScrollContainerProvider>
+            <PageContent pageId={app.launch.pageId} />
+          </PageScrollContainerProvider>
+        </div>
+      );
+    case 'text-file':
+      return (
+        <Suspense fallback={<div className='p-4 text-sm text-[#667085]'>Loading...</div>}>
+          <NotepadWindowBody fileId={app.launch.fileId} />
+        </Suspense>
+      );
+    case 'terminal':
+      return (
+        <Suspense fallback={<div className='p-4 text-sm text-[#667085]'>Loading...</div>}>
+          <TerminalWindowBody />
+        </Suspense>
+      );
+    case 'code': {
+      const workspace = CODE_WORKSPACES[app.launch.workspaceId];
+      return (
+        <Suspense fallback={<div className='p-4 text-sm text-[#667085]'>Loading...</div>}>
+          <Github1sCodeWindow
+            owner={workspace.owner}
+            repo={workspace.repo}
+            branch={workspace.branch}
+            path={workspace.path}
+            title={workspace.title}
+          />
+        </Suspense>
+      );
+    }
+  }
+}
+
+function PhoneAppScreen({
+  app,
+  onBack,
+}: {
+  app: PhoneActiveApp;
+  onBack: () => void;
+}) {
+  return (
+    <div className='flex h-full min-h-0 flex-col bg-[#f8fafc] text-[#111827]'>
+      <div className='flex h-[58px] shrink-0 items-center gap-3 border-b border-black/5 bg-[#f8fafc]/96 px-3 backdrop-blur-xl'>
+        <button
+          type='button'
+          onClick={onBack}
+          className='grid h-11 w-11 place-items-center rounded-full text-[#111827] active:bg-black/6'
+          aria-label='Back'
+        >
+          <BackIcon />
+        </button>
+        <img src={app.icon} alt='' className='h-9 w-9 rounded-[14px] object-cover' />
+        <div className='min-w-0 flex-1 truncate text-[18px] font-semibold'>
+          {app.title}
+        </div>
+      </div>
+      <div className='min-h-0 flex-1 overflow-hidden'>
+        <PhoneAppContent app={app} />
+      </div>
+    </div>
+  );
+}
+
+function PhoneNavigationBar({
+  activeApp,
+  onRecents,
+  onHome,
+  onBack,
+}: {
+  activeApp: boolean;
+  onRecents: () => void;
+  onHome: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div
+      className={[
+        'flex h-11 shrink-0 items-center justify-around px-10',
+        activeApp ? 'bg-[#f8fafc] text-[#111827]' : 'bg-transparent text-white',
+      ].join(' ')}
+    >
+      <button
+        type='button'
+        onClick={onRecents}
+        className='grid h-10 w-14 place-items-center rounded-full active:bg-black/8'
+        aria-label='Recent apps'
+      >
+        <RecentIcon />
+      </button>
+      <button
+        type='button'
+        onClick={onHome}
+        className='grid h-10 w-14 place-items-center rounded-full active:bg-black/8'
+        aria-label='Home'
+      >
+        <HomeIcon />
+      </button>
+      <button
+        type='button'
+        onClick={onBack}
+        className='grid h-10 w-14 place-items-center rounded-full active:bg-black/8'
+        aria-label='Back'
+      >
+        <BackIcon />
+      </button>
+    </div>
+  );
+}
+
+function sameActiveApp(a: PhoneActiveApp, b: PhoneActiveApp) {
+  return a.key === b.key;
+}
+
+export function GalaxyPhoneShell({
+  initialApp,
+}: {
+  initialApp?: PhoneInitialApp;
+}) {
+  const now = useClock();
+  const swipeStartYRef = useRef<number | null>(null);
+  const soundEnabled = useDesktopPreferencesStore((s) => s.soundEnabled);
+  const toggleSound = useDesktopPreferencesStore((s) => s.toggleSound);
+  const [activeApp, setActiveApp] = useState<PhoneActiveApp | null>(() =>
+    initialApp ? getActiveAppFromLaunch(initialApp) : null
+  );
+  const [recentApps, setRecentApps] = useState<PhoneActiveApp[]>(() =>
+    initialApp ? [getActiveAppFromLaunch(initialApp)] : []
+  );
+  const [openFolderId, setOpenFolderId] = useState<PhoneFolderId | null>(null);
+  const [quickPanelOpen, setQuickPanelOpen] = useState(false);
+  const [appDrawerOpen, setAppDrawerOpen] = useState(false);
+  const [recentsOpen, setRecentsOpen] = useState(false);
+  const [drawerQuery, setDrawerQuery] = useState('');
+
+  const initialKey = initialApp ? getLaunchKey(initialApp) : 'home';
+
+  useImagePreload(PHONE_IMAGE_ASSETS);
+
+  useEffect(() => {
+    if (!initialApp) return;
+    const nextApp = getActiveAppFromLaunch(initialApp);
+    setActiveApp(nextApp);
+    setRecentApps((current) => [
+      nextApp,
+      ...current.filter((entry) => !sameActiveApp(entry, nextApp)),
+    ].slice(0, 6));
+  }, [initialApp, initialKey]);
+
+  const statusDark = Boolean(activeApp);
+
+  const launchRunnableApp = (nextApp: PhoneActiveApp) => {
+    setActiveApp(nextApp);
+    setOpenFolderId(null);
+    setAppDrawerOpen(false);
+    setRecentsOpen(false);
+    setQuickPanelOpen(false);
+    setDrawerQuery('');
+    setRecentApps((current) => [
+      nextApp,
+      ...current.filter((entry) => !sameActiveApp(entry, nextApp)),
+    ].slice(0, 6));
+  };
+
+  const launchApp = (app: PhoneApp) => {
+    if (app.launch.kind === 'folder') {
+      setOpenFolderId(app.launch.folderId);
+      setAppDrawerOpen(false);
+      setQuickPanelOpen(false);
+      return;
+    }
+
+    launchRunnableApp(getActiveAppFromLaunch(app.launch));
+  };
+
+  const goHome = () => {
+    setActiveApp(null);
+    setOpenFolderId(null);
+    setQuickPanelOpen(false);
+    setAppDrawerOpen(false);
+    setRecentsOpen(false);
+    setDrawerQuery('');
+  };
+
+  const goBack = () => {
+    if (quickPanelOpen) {
+      setQuickPanelOpen(false);
+      return;
+    }
+    if (recentsOpen) {
+      setRecentsOpen(false);
+      return;
+    }
+    if (openFolderId) {
+      setOpenFolderId(null);
+      return;
+    }
+    if (appDrawerOpen) {
+      setAppDrawerOpen(false);
+      setDrawerQuery('');
+      return;
+    }
+    if (activeApp) {
+      setActiveApp(null);
+    }
+  };
+
+  const handleHomePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    swipeStartYRef.current = event.clientY;
+  };
+
+  const handleHomePointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    if (swipeStartYRef.current === null) return;
+    const deltaY = swipeStartYRef.current - event.clientY;
+    swipeStartYRef.current = null;
+    if (deltaY > 64) {
+      setAppDrawerOpen(true);
+    }
+  };
+
+  const resumeRecentApp = (app: PhoneActiveApp) => {
+    launchRunnableApp(app);
+  };
+
+  const openSettings = () => {
+    const settingsApp = PHONE_APP_BY_ID.get('settings');
+    if (settingsApp) {
+      launchApp(settingsApp);
+    }
+  };
+
+  const wallpaperStyle = useMemo(
+    () => ({
+      backgroundImage:
+        'linear-gradient(145deg, rgba(9,20,44,0.88) 0%, rgba(39,44,91,0.62) 34%, rgba(165,68,128,0.5) 62%, rgba(32,146,156,0.64) 100%), linear-gradient(28deg, #07111f 0%, #172554 32%, #5b2f87 58%, #0f766e 100%)',
+    }),
+    []
+  );
+
+  return (
+    <div
+      className='relative h-full w-full overflow-hidden bg-[#07111f] text-white'
+      style={wallpaperStyle}
+    >
+      <div className='absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.08)_0%,rgba(255,255,255,0)_22%,rgba(0,0,0,0.16)_100%)]' />
+      <div className='relative z-10 flex h-full min-h-0 flex-col'>
+        <div className={statusDark ? 'bg-[#f8fafc]' : 'bg-transparent'}>
+          <PhoneStatusBar
+            now={now}
+            dark={statusDark}
+            onOpenQuickPanel={() => setQuickPanelOpen(true)}
+          />
+        </div>
+
+        <main className='relative min-h-0 flex-1 overflow-hidden'>
+          {activeApp ? (
+            <PhoneAppScreen app={activeApp} onBack={goBack} />
+          ) : (
+            <HomeScreen
+              now={now}
+              onLaunch={launchApp}
+              onOpenDrawer={() => setAppDrawerOpen(true)}
+              onPointerDown={handleHomePointerDown}
+              onPointerUp={handleHomePointerUp}
+            />
+          )}
+        </main>
+
+        <PhoneNavigationBar
+          activeApp={Boolean(activeApp)}
+          onRecents={() => {
+            setRecentsOpen(true);
+            setQuickPanelOpen(false);
+            setOpenFolderId(null);
+            setAppDrawerOpen(false);
+          }}
+          onHome={goHome}
+          onBack={goBack}
+        />
+      </div>
+
+      <QuickSettingsPanel
+        open={quickPanelOpen}
+        now={now}
+        soundEnabled={soundEnabled}
+        onClose={() => setQuickPanelOpen(false)}
+        onToggleSound={toggleSound}
+        onOpenSettings={openSettings}
+      />
+      <FolderOverlay
+        folderId={openFolderId}
+        onClose={() => setOpenFolderId(null)}
+        onLaunch={launchApp}
+      />
+      <AppDrawer
+        open={appDrawerOpen}
+        query={drawerQuery}
+        onQueryChange={setDrawerQuery}
+        onClose={() => {
+          setAppDrawerOpen(false);
+          setDrawerQuery('');
+        }}
+        onLaunch={launchApp}
+      />
+      <RecentsOverlay
+        open={recentsOpen}
+        recentApps={recentApps}
+        onClose={() => setRecentsOpen(false)}
+        onResume={resumeRecentApp}
+      />
+    </div>
+  );
+}

--- a/src/features/mobile/config/galaxyShell.ts
+++ b/src/features/mobile/config/galaxyShell.ts
@@ -1,0 +1,348 @@
+import type { CodeWorkspaceId, PageType, TextFileId } from '@/stores';
+
+const svgDataUri = (markup: string) =>
+  `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(markup)}`;
+
+const phoneSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <defs>
+      <linearGradient id="g" x1="8" x2="64" y1="64" y2="8">
+        <stop offset="0" stop-color="#03a86b"/>
+        <stop offset="1" stop-color="#7be8a3"/>
+      </linearGradient>
+    </defs>
+    <rect width="72" height="72" rx="22" fill="url(#g)"/>
+    <path d="M25.5 20.5c-2.4 1.5-3.2 6.1-1.9 10.9 1.8 6.9 7.1 13.5 13.4 17.2 4.8 2.8 9.7 3.3 11.8 1.2l2.3-2.4c1.1-1.1 1-2.9-.2-3.9l-5.5-4.5c-1-.8-2.5-.8-3.5.1l-2.6 2.4c-4-2.2-7.1-5.4-9.3-9.5l2.4-2.4c1-1 1.1-2.5.3-3.6l-4.1-5.3c-.8-1.2-2.4-1.5-3.1-.2z" fill="#fff"/>
+  </svg>
+`;
+
+const messagesSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <defs>
+      <linearGradient id="g" x1="8" x2="64" y1="64" y2="8">
+        <stop offset="0" stop-color="#1fb36c"/>
+        <stop offset="1" stop-color="#74eec1"/>
+      </linearGradient>
+    </defs>
+    <rect width="72" height="72" rx="22" fill="url(#g)"/>
+    <path d="M18 22.5c0-3 2.4-5.5 5.5-5.5h25c3 0 5.5 2.4 5.5 5.5v16c0 3-2.4 5.5-5.5 5.5H35L23.5 54v-10H23c-2.8-.2-5-2.6-5-5.4z" fill="#fff"/>
+    <path d="M27 29h18M27 36h13" stroke="#20b76d" stroke-width="3.5" stroke-linecap="round"/>
+  </svg>
+`;
+
+const internetSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <defs>
+      <linearGradient id="g" x1="9" x2="63" y1="60" y2="10">
+        <stop offset="0" stop-color="#1a65ff"/>
+        <stop offset=".52" stop-color="#31b7ff"/>
+        <stop offset="1" stop-color="#8cf4ff"/>
+      </linearGradient>
+    </defs>
+    <rect width="72" height="72" rx="22" fill="url(#g)"/>
+    <circle cx="36" cy="36" r="19" fill="none" stroke="#fff" stroke-width="5"/>
+    <path d="M17 39c12 5.5 25 1.2 38-12M28 18c4.8 10.8 4.8 24.4 0 36M44 18c-4.8 10.8-4.8 24.4 0 36" fill="none" stroke="#fff" stroke-width="3.2" stroke-linecap="round"/>
+  </svg>
+`;
+
+const filesSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <defs>
+      <linearGradient id="g" x1="9" x2="63" y1="62" y2="11">
+        <stop offset="0" stop-color="#f1a400"/>
+        <stop offset="1" stop-color="#ffd75d"/>
+      </linearGradient>
+    </defs>
+    <rect width="72" height="72" rx="22" fill="url(#g)"/>
+    <path d="M16 27c0-3.2 2.6-5.8 5.8-5.8h10.8l5 5.8h12.6c3.2 0 5.8 2.6 5.8 5.8v14.4c0 3.2-2.6 5.8-5.8 5.8H21.8c-3.2 0-5.8-2.6-5.8-5.8z" fill="#fff" opacity=".95"/>
+    <path d="M16 31.5h40" stroke="#f5b315" stroke-width="3.5"/>
+  </svg>
+`;
+
+const settingsSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <defs>
+      <linearGradient id="g" x1="9" x2="63" y1="63" y2="9">
+        <stop offset="0" stop-color="#667085"/>
+        <stop offset="1" stop-color="#d0d5dd"/>
+      </linearGradient>
+    </defs>
+    <rect width="72" height="72" rx="22" fill="url(#g)"/>
+    <path d="M36 19.5 40 23l5.2-1.3 3.5 6.1-3.8 3.8c.2 1.4.2 2.8 0 4.2l3.8 3.8-3.5 6.1L40 44.5l-4 3.5-4-3.5-5.2 1.3-3.5-6.1 3.8-3.8a17 17 0 0 1 0-4.2l-3.8-3.8 3.5-6.1L32 23z" fill="#fff"/>
+    <circle cx="36" cy="36" r="7.2" fill="#8a94a6"/>
+  </svg>
+`;
+
+const notesSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <defs>
+      <linearGradient id="g" x1="9" x2="63" y1="63" y2="9">
+        <stop offset="0" stop-color="#facc15"/>
+        <stop offset="1" stop-color="#fff2a8"/>
+      </linearGradient>
+    </defs>
+    <rect width="72" height="72" rx="22" fill="url(#g)"/>
+    <rect x="21" y="15" width="30" height="42" rx="6" fill="#fff"/>
+    <path d="M27 27h18M27 35h18M27 43h12" stroke="#d9a900" stroke-width="3" stroke-linecap="round"/>
+  </svg>
+`;
+
+const terminalSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <defs>
+      <linearGradient id="g" x1="9" x2="63" y1="63" y2="9">
+        <stop offset="0" stop-color="#111827"/>
+        <stop offset="1" stop-color="#475569"/>
+      </linearGradient>
+    </defs>
+    <rect width="72" height="72" rx="22" fill="url(#g)"/>
+    <path d="M21 28.5 31 36l-10 7.5" fill="none" stroke="#7dd3fc" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M36 45h15" stroke="#fff" stroke-width="5" stroke-linecap="round"/>
+  </svg>
+`;
+
+const profileSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <defs>
+      <linearGradient id="g" x1="9" x2="63" y1="63" y2="9">
+        <stop offset="0" stop-color="#3b82f6"/>
+        <stop offset=".55" stop-color="#9b7cff"/>
+        <stop offset="1" stop-color="#f472b6"/>
+      </linearGradient>
+    </defs>
+    <rect width="72" height="72" rx="22" fill="url(#g)"/>
+    <circle cx="36" cy="29" r="10" fill="#fff"/>
+    <path d="M18 55c2.8-9.4 9.4-14.4 18-14.4S51.2 45.6 54 55" fill="#fff"/>
+  </svg>
+`;
+
+const awardsSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <defs>
+      <linearGradient id="g" x1="10" x2="62" y1="62" y2="10">
+        <stop offset="0" stop-color="#ea580c"/>
+        <stop offset=".48" stop-color="#f97316"/>
+        <stop offset="1" stop-color="#fde047"/>
+      </linearGradient>
+    </defs>
+    <rect width="72" height="72" rx="22" fill="url(#g)"/>
+    <path d="M27 17h18v18.5a9 9 0 0 1-18 0z" fill="#fff"/>
+    <path d="M26 24h-7v7a8 8 0 0 0 8 8M46 24h7v7a8 8 0 0 1-8 8" fill="none" stroke="#fff" stroke-width="5" stroke-linecap="round"/>
+    <path d="M32 51h8l2.5 6h-13z" fill="#fff"/>
+  </svg>
+`;
+
+const codeSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <defs>
+      <linearGradient id="g" x1="9" x2="63" y1="63" y2="9">
+        <stop offset="0" stop-color="#075985"/>
+        <stop offset="1" stop-color="#38bdf8"/>
+      </linearGradient>
+    </defs>
+    <rect width="72" height="72" rx="22" fill="url(#g)"/>
+    <path d="M29 24 18 36l11 12M43 24l11 12-11 12" fill="none" stroke="#fff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="m39 20-6 32" stroke="#e0f2fe" stroke-width="4" stroke-linecap="round"/>
+  </svg>
+`;
+
+const githubSvg = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+    <rect width="72" height="72" rx="22" fill="#171717"/>
+    <circle cx="36" cy="36" r="21" fill="#fff"/>
+    <path d="M36 18.5c-9.9 0-18 8-18 18 0 7.9 5.1 14.6 12.2 17 .9.2 1.2-.4 1.2-.9v-3.1c-5 1.1-6-2.1-6-2.1-.8-2-2-2.6-2-2.6-1.6-1.1.1-1.1.1-1.1 1.8.1 2.8 1.9 2.8 1.9 1.6 2.8 4.2 2 5.2 1.5.2-1.2.6-2 1.1-2.4-4-.5-8.2-2-8.2-8.8 0-1.9.7-3.5 1.8-4.8-.2-.4-.8-2.3.2-4.8 0 0 1.5-.5 4.9 1.8a17 17 0 0 1 8.9 0c3.4-2.3 4.9-1.8 4.9-1.8 1 2.5.4 4.4.2 4.8 1.1 1.3 1.8 2.9 1.8 4.8 0 6.8-4.2 8.3-8.2 8.8.7.6 1.2 1.7 1.2 3.4v4.5c0 .5.3 1.1 1.2.9A18 18 0 0 0 54 36.5c0-10-8.1-18-18-18z" fill="#171717"/>
+  </svg>
+`;
+
+export const PHONE_SYSTEM_ICONS = {
+  phone: svgDataUri(phoneSvg),
+  messages: svgDataUri(messagesSvg),
+  internet: svgDataUri(internetSvg),
+  files: svgDataUri(filesSvg),
+  settings: svgDataUri(settingsSvg),
+  notes: svgDataUri(notesSvg),
+  terminal: svgDataUri(terminalSvg),
+  profile: svgDataUri(profileSvg),
+  awards: svgDataUri(awardsSvg),
+  code: svgDataUri(codeSvg),
+  github: svgDataUri(githubSvg),
+} as const;
+
+export type PhoneFolderId = 'portfolio' | 'projects' | 'social' | 'tools';
+
+export type PhoneLaunch =
+  | { kind: 'page'; pageId: PageType }
+  | { kind: 'folder'; folderId: PhoneFolderId }
+  | { kind: 'text-file'; fileId: TextFileId }
+  | { kind: 'terminal' }
+  | { kind: 'code'; workspaceId: CodeWorkspaceId };
+
+export type PhoneApp = {
+  id: string;
+  label: string;
+  icon: string;
+  launch: PhoneLaunch;
+  system?: boolean;
+};
+
+export const PHONE_APPS: PhoneApp[] = [
+  {
+    id: 'phone',
+    label: 'Phone',
+    icon: PHONE_SYSTEM_ICONS.phone,
+    launch: { kind: 'text-file', fileId: 'contact' },
+    system: true,
+  },
+  {
+    id: 'messages',
+    label: 'Messages',
+    icon: PHONE_SYSTEM_ICONS.messages,
+    launch: { kind: 'text-file', fileId: 'now' },
+    system: true,
+  },
+  {
+    id: 'internet',
+    label: 'Internet',
+    icon: PHONE_SYSTEM_ICONS.internet,
+    launch: { kind: 'page', pageId: 'chrome' },
+    system: true,
+  },
+  {
+    id: 'my-files',
+    label: 'My Files',
+    icon: PHONE_SYSTEM_ICONS.files,
+    launch: { kind: 'folder', folderId: 'projects' },
+    system: true,
+  },
+  {
+    id: 'profile',
+    label: 'Profile',
+    icon: PHONE_SYSTEM_ICONS.profile,
+    launch: { kind: 'page', pageId: 'about' },
+  },
+  {
+    id: 'portfolio',
+    label: 'Portfolio',
+    icon: PHONE_SYSTEM_ICONS.profile,
+    launch: { kind: 'folder', folderId: 'portfolio' },
+  },
+  {
+    id: 'projects',
+    label: 'Projects',
+    icon: PHONE_SYSTEM_ICONS.files,
+    launch: { kind: 'folder', folderId: 'projects' },
+  },
+  {
+    id: 'social',
+    label: 'Social',
+    icon: PHONE_SYSTEM_ICONS.github,
+    launch: { kind: 'folder', folderId: 'social' },
+  },
+  {
+    id: 'awards',
+    label: 'Awards',
+    icon: PHONE_SYSTEM_ICONS.awards,
+    launch: { kind: 'page', pageId: 'awards' },
+  },
+  {
+    id: 'github',
+    label: 'GitHub',
+    icon: PHONE_SYSTEM_ICONS.github,
+    launch: { kind: 'page', pageId: 'github' },
+  },
+  {
+    id: 'blog',
+    label: 'Blog',
+    icon: '/assets/common/brands/blog.webp',
+    launch: { kind: 'page', pageId: 'blog' },
+  },
+  {
+    id: 'instagram',
+    label: 'Instagram',
+    icon: '/assets/common/brands/instagram.webp',
+    launch: { kind: 'page', pageId: 'insta' },
+  },
+  {
+    id: 'notes',
+    label: 'Notes',
+    icon: PHONE_SYSTEM_ICONS.notes,
+    launch: { kind: 'text-file', fileId: 'readme' },
+  },
+  {
+    id: 'resume',
+    label: 'Resume',
+    icon: PHONE_SYSTEM_ICONS.notes,
+    launch: { kind: 'text-file', fileId: 'resume' },
+  },
+  {
+    id: 'terminal',
+    label: 'Terminal',
+    icon: PHONE_SYSTEM_ICONS.terminal,
+    launch: { kind: 'terminal' },
+  },
+  {
+    id: 'code',
+    label: 'Code',
+    icon: PHONE_SYSTEM_ICONS.code,
+    launch: { kind: 'code', workspaceId: 'portfolio-workspace' },
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    icon: PHONE_SYSTEM_ICONS.settings,
+    launch: { kind: 'page', pageId: 'settings' },
+    system: true,
+  },
+  {
+    id: 'comatching',
+    label: 'COMATCHING',
+    icon: '/assets/projects/comatching/comatching-icon.webp',
+    launch: { kind: 'page', pageId: 'comatching' },
+  },
+  {
+    id: 'share-it',
+    label: 'Share-It',
+    icon: '/assets/projects/share-it/share-it-icon.webp',
+    launch: { kind: 'page', pageId: 'share-it' },
+  },
+  {
+    id: 'alnc',
+    label: 'ALNC',
+    icon: '/assets/projects/alnc/alnc-icon.webp',
+    launch: { kind: 'page', pageId: 'alnc' },
+  },
+];
+
+export const PHONE_HOME_APP_IDS = [
+  'portfolio',
+  'projects',
+  'awards',
+  'github',
+  'blog',
+  'instagram',
+  'notes',
+  'terminal',
+] as const;
+
+export const PHONE_DOCK_APP_IDS = [
+  'phone',
+  'messages',
+  'internet',
+  'settings',
+] as const;
+
+export const PHONE_FOLDER_APP_IDS: Record<PhoneFolderId, string[]> = {
+  portfolio: ['profile', 'resume', 'notes', 'awards', 'phone', 'messages'],
+  projects: ['comatching', 'share-it', 'alnc', 'code'],
+  social: ['github', 'blog', 'instagram'],
+  tools: ['internet', 'terminal', 'code', 'settings'],
+};
+
+export const PHONE_FOLDER_TITLES: Record<PhoneFolderId, string> = {
+  portfolio: 'Portfolio',
+  projects: 'Projects',
+  social: 'Social',
+  tools: 'Tools',
+};
+
+export const PHONE_APP_BY_ID = new Map(PHONE_APPS.map((app) => [app.id, app]));

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,26 +1,46 @@
+import { useEffect, useState } from 'react';
 import { getWallpaperStyle } from '@/features/desktop/config/shell';
 import { DesktopSurface } from '@/features/desktop/components/DesktopSurface';
 import { DESKTOP_FEATURED_ASSETS } from '@/config/featured-assets';
 import { useDesktopPreferencesStore } from '@/stores';
 import Desktop from '@/features/desktop/components/Desktop';
+import { GalaxyPhoneShell } from '@/features/mobile/components/GalaxyPhoneShell';
 import { useImagePreload } from '@/utils/preloadAssets';
 
 export default function MainPage() {
   const wallpaperId = useDesktopPreferencesStore((s) => s.wallpaperId);
+  const [preloadDesktopAssets, setPreloadDesktopAssets] = useState(() =>
+    typeof window === 'undefined'
+      ? true
+      : window.matchMedia('(min-width: 768px)').matches
+  );
 
-  useImagePreload(DESKTOP_FEATURED_ASSETS);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(min-width: 768px)');
+    const update = () => setPreloadDesktopAssets(mediaQuery.matches);
+    update();
+    mediaQuery.addEventListener('change', update);
+    return () => mediaQuery.removeEventListener('change', update);
+  }, []);
+
+  useImagePreload(DESKTOP_FEATURED_ASSETS, { enabled: preloadDesktopAssets });
 
   return (
-    <div
-      className='
-        relative w-screen h-screen
-        bg-cover bg-center bg-no-repeat
-        text-white
-      '
-      style={getWallpaperStyle(wallpaperId)}
-    >
-      <DesktopSurface />
-      <Desktop />
+    <div className='relative h-screen w-screen overflow-hidden'>
+      <div
+        className='
+          relative hidden h-full w-full
+          bg-cover bg-center bg-no-repeat
+          text-white md:block
+        '
+        style={getWallpaperStyle(wallpaperId)}
+      >
+        <DesktopSurface />
+        <Desktop />
+      </div>
+      <div className='block h-full w-full md:hidden'>
+        <GalaxyPhoneShell />
+      </div>
     </div>
   );
 }

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,5 +1,9 @@
 import { Routes, Route } from 'react-router-dom';
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, type ReactNode } from 'react';
+import {
+  GalaxyPhoneShell,
+  type PhoneInitialApp,
+} from '@/features/mobile/components/GalaxyPhoneShell';
 
 const MainPage = lazy(() => import('@/pages/MainPage'));
 const ProfilePage = lazy(() => import('@/pages/ProfilePage'));
@@ -19,18 +23,91 @@ const ShareIt = lazy(() => import('@/features/projects/share-it/Page'));
 const ALNC = lazy(() => import('@/features/projects/alnc/Page'));
 const NotFoundPage = lazy(() => import('@/pages/NotFoundPage'));
 
+function MobileAwareRoute({
+  initialApp,
+  children,
+}: {
+  initialApp: PhoneInitialApp;
+  children: ReactNode;
+}) {
+  return (
+    <>
+      <div className='hidden min-h-screen md:block'>{children}</div>
+      <div className='block h-screen md:hidden'>
+        <GalaxyPhoneShell initialApp={initialApp} />
+      </div>
+    </>
+  );
+}
+
 const AppRoutes = () => (
   <Suspense fallback={<div className='p-4 text-white/80'>Loading...</div>}>
     <Routes>
       <Route path='/' element={<MainPage />} />
-      <Route path='/profile' element={<ProfilePage />} />
-      <Route path='/prize' element={<PrizePage />} />
-      <Route path='/github' element={<GitHubProfilePanel />} />
-      <Route path='/settings' element={<SettingsPage />} />
-      <Route path='/comatching' element={<COMATCHING />} />
-      <Route path='/share-it' element={<ShareIt />} />
-      <Route path='/shareit' element={<ShareIt />} />
-      <Route path='/alnc' element={<ALNC />} />
+      <Route
+        path='/profile'
+        element={
+          <MobileAwareRoute initialApp={{ kind: 'page', pageId: 'about' }}>
+            <ProfilePage />
+          </MobileAwareRoute>
+        }
+      />
+      <Route
+        path='/prize'
+        element={
+          <MobileAwareRoute initialApp={{ kind: 'page', pageId: 'awards' }}>
+            <PrizePage />
+          </MobileAwareRoute>
+        }
+      />
+      <Route
+        path='/github'
+        element={
+          <MobileAwareRoute initialApp={{ kind: 'page', pageId: 'github' }}>
+            <GitHubProfilePanel />
+          </MobileAwareRoute>
+        }
+      />
+      <Route
+        path='/settings'
+        element={
+          <MobileAwareRoute initialApp={{ kind: 'page', pageId: 'settings' }}>
+            <SettingsPage />
+          </MobileAwareRoute>
+        }
+      />
+      <Route
+        path='/comatching'
+        element={
+          <MobileAwareRoute initialApp={{ kind: 'page', pageId: 'comatching' }}>
+            <COMATCHING />
+          </MobileAwareRoute>
+        }
+      />
+      <Route
+        path='/share-it'
+        element={
+          <MobileAwareRoute initialApp={{ kind: 'page', pageId: 'share-it' }}>
+            <ShareIt />
+          </MobileAwareRoute>
+        }
+      />
+      <Route
+        path='/shareit'
+        element={
+          <MobileAwareRoute initialApp={{ kind: 'page', pageId: 'share-it' }}>
+            <ShareIt />
+          </MobileAwareRoute>
+        }
+      />
+      <Route
+        path='/alnc'
+        element={
+          <MobileAwareRoute initialApp={{ kind: 'page', pageId: 'alnc' }}>
+            <ALNC />
+          </MobileAwareRoute>
+        }
+      />
       <Route path='*' element={<NotFoundPage />} />
     </Routes>
   </Suspense>


### PR DESCRIPTION
## Summary
- Add a Galaxy/One UI style mobile shell for sub-768px viewports.
- Keep the existing Windows desktop shell for desktop widths.
- Route mobile deep links into full-screen app views.

## Validation
- npm run build
- Playwright mobile checks for home, folder, app drawer, quick panel, app launch, and /profile route
- Playwright desktop check at 1280x800